### PR TITLE
Add option for natural sorting and make it default, fix ascii sort

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+# Config file for travis-ci.org
+
+language: php
+php:
+  - "5.5"
+  - "5.4"
+  - "5.3"
+env:
+  - DOKUWIKI=master
+  - DOKUWIKI=stable
+before_install: wget https://raw.github.com/splitbrain/dokuwiki-travis/master/travis.sh
+install: sh travis.sh
+script: cd _test && phpunit --stderr --group plugin_uncmap

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,4 +10,4 @@ env:
   - DOKUWIKI=stable
 before_install: wget https://raw.github.com/splitbrain/dokuwiki-travis/master/travis.sh
 install: sh travis.sh
-script: cd _test && phpunit --stderr --group plugin_uncmap
+script: cd _test && phpunit --stderr --group plugin_simplenavi

--- a/_test/simplenavi.test.php
+++ b/_test/simplenavi.test.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * General tests for the simplenavi plugin
+ *
+ * @author  Michael Große <grosse@cosmocode.de>
+ *
+ * @group Michael Grosse
+ * @group plugin_simplenavi
+ * @group plugins
+ */
+
+class parser_plugin_simplenavi_test extends DokuWikiTest {
+
+    protected $pluginsEnabled = array('simplenavi');
+
+    function setUp() {
+        parent::setUp();
+        saveWikiText('sidebar', '{{simplenavi>}}', 'create test sidebar');
+        saveWikiText('namespace1:foo', 'bar', 'foobar');
+        saveWikiText('namespace2:foo', 'bar', 'foobar');
+        saveWikiText('namespace12:foo', 'bar', 'foobar');
+        saveWikiText('namespace123:foo', 'bar', 'foobar');
+        saveWikiText('namespace21:foo', 'bar', 'foobar');
+
+    }
+
+    function tearDown() {
+        parent::tearDown();
+
+    }
+
+    function test_output_natural() {
+        global $ID, $conf;
+        $conf['plugin']['simplenavi']['sort'] = 'natural';
+
+        $ID = 'wiki:start';
+        $request = new TestRequest();
+        $input = array(
+            'id' => 'namespace1:foo'
+        );
+        saveWikiText('wiki:start', 'some text', 'Test init');
+        $response = $request->post($input);
+        $naviBegin = strpos($response->getContent(), '<!-- ********** ASIDE ********** -->')+36;
+        $naviEnd = strpos($response->getContent(), '<!-- /aside -->');
+        $navi = substr($response->getContent(),$naviBegin,$naviEnd-$naviBegin);
+        $navilines = explode("\n",$navi);
+        $listlines = array();
+        foreach ($navilines as $line) {
+            if (substr($line,0,4) != '<li ') continue;
+            if (strpos($line,'namespace') === false) continue;
+            $listlines[] = $line;
+        }
+
+        $this->assertTrue(strpos($listlines[0],'href="/./doku.php?id=namespace1:start"') !== false, 'namespace1 should be before other namespaces and espacially before its subpages and namespaces');
+        $this->assertTrue(strpos($listlines[1],'href="/./doku.php?id=namespace1:foo"') !== false, 'level2 should follow open level1');
+        $this->assertTrue(strpos($listlines[2],'href="/./doku.php?id=namespace2:start"') !== false, 'namespace2 should be after namespace1 and its pages.');
+        $this->assertTrue(strpos($listlines[3],'href="/./doku.php?id=namespace12:start"') !== false, 'namespace12 should be after namespace2.');
+        $this->assertTrue(strpos($listlines[4],'href="/./doku.php?id=namespace21:start"') !== false, 'namespace21 should be after namespace12.');
+        $this->assertTrue(strpos($listlines[5],'href="/./doku.php?id=namespace123:start"') !== false, 'namespace123 should be after namespace21.');
+    }
+
+    
+
+}
+
+
+

--- a/_test/simplenavi.test.php
+++ b/_test/simplenavi.test.php
@@ -4,7 +4,7 @@
  *
  * @author  Michael Große <grosse@cosmocode.de>
  *
- * @group Michael Grosse
+ * @group Michael Große <grosse@cosmocode.de>
  * @group plugin_simplenavi
  * @group plugins
  */
@@ -29,6 +29,9 @@ class parser_plugin_simplenavi_test extends DokuWikiTest {
 
     }
 
+    /**
+     * @covers syntax_plugin_simplenavi
+     */
     function test_output_natural() {
         global $ID, $conf;
         $conf['plugin']['simplenavi']['sort'] = 'natural';
@@ -59,6 +62,9 @@ class parser_plugin_simplenavi_test extends DokuWikiTest {
         $this->assertTrue(strpos($listlines[5],'href="/./doku.php?id=namespace123:start"') !== false, 'namespace123 should be after namespace21.');
     }
 
+    /**
+     * @covers syntax_plugin_simplenavi
+     */
     function test_output_ascii() {
         global $ID, $conf;
         $conf['plugin']['simplenavi']['sort'] = 'ascii';

--- a/_test/simplenavi.test.php
+++ b/_test/simplenavi.test.php
@@ -59,7 +59,35 @@ class parser_plugin_simplenavi_test extends DokuWikiTest {
         $this->assertTrue(strpos($listlines[5],'href="/./doku.php?id=namespace123:start"') !== false, 'namespace123 should be after namespace21.');
     }
 
-    
+    function test_output_ascii() {
+        global $ID, $conf;
+        $conf['plugin']['simplenavi']['sort'] = 'ascii';
+
+        $ID = 'wiki:start';
+        $request = new TestRequest();
+        $input = array(
+            'id' => 'namespace1:foo'
+        );
+        saveWikiText('wiki:start', 'some text', 'Test init');
+        $response = $request->post($input);
+        $naviBegin = strpos($response->getContent(), '<!-- ********** ASIDE ********** -->')+36;
+        $naviEnd = strpos($response->getContent(), '<!-- /aside -->');
+        $navi = substr($response->getContent(),$naviBegin,$naviEnd-$naviBegin);
+        $navilines = explode("\n",$navi);
+        $listlines = array();
+        foreach ($navilines as $line) {
+            if (substr($line,0,4) != '<li ') continue;
+            if (strpos($line,'namespace') === false) continue;
+            $listlines[] = $line;
+        }
+
+        $this->assertTrue(strpos($listlines[0],'href="/./doku.php?id=namespace1:start"') !== false, 'namespace1 should be before other namespaces and espacially before its subpages and namespaces');
+        $this->assertTrue(strpos($listlines[1],'href="/./doku.php?id=namespace1:foo"') !== false, 'level2 should follow open level1.');
+        $this->assertTrue(strpos($listlines[2],'href="/./doku.php?id=namespace12:start"') !== false, 'namespace12 should be after namespace1 and its pages.');
+        $this->assertTrue(strpos($listlines[3],'href="/./doku.php?id=namespace123:start"') !== false, 'namespace123 should be after namespace12.');
+        $this->assertTrue(strpos($listlines[4],'href="/./doku.php?id=namespace2:start"') !== false, 'namespace2 should be after namespace123.');
+        $this->assertTrue(strpos($listlines[5],'href="/./doku.php?id=namespace21:start"') !== false, 'namespace21 should be after namespace2.');
+    }
 
 }
 

--- a/conf/default.php
+++ b/conf/default.php
@@ -1,0 +1,7 @@
+<?php
+/**
+ * Default settings for the simplenavi plugin
+ *
+ * @author  Michael Große <grosse@cosmocode.de>
+ */
+$conf['sort'] = 'natural';

--- a/conf/metadata.php
+++ b/conf/metadata.php
@@ -1,0 +1,11 @@
+<?php
+/**
+ * Options for the latexit plugin
+ *
+ * @author  Michael Große <grosse@cosmocode.de>
+ */
+$meta['sort'] = array('multichoice',
+                      '_choices' =>
+                      array('ascii',
+                            'natural'
+                      ));

--- a/lang/en/settings.php
+++ b/lang/en/settings.php
@@ -1,0 +1,8 @@
+<?php
+/**
+ * english language file for latexit plugin
+ *
+ * @author  Michael Große <grosse@cosmocode.de>
+ */
+
+$lang['sort'] = 'Sort order';

--- a/plugin.info.txt
+++ b/plugin.info.txt
@@ -1,7 +1,7 @@
 base   simplenavi
 author Andreas Gohr
 email  gohr@cosmocode.de
-date   2014-01-31
+date   2015-01-07
 name   simplenavi plugin
 desc   Create a simple navigation tree based on namespaces
 url    http://www.dokuwiki.org/plugin:simplenavi

--- a/syntax.php
+++ b/syntax.php
@@ -157,9 +157,10 @@ class syntax_plugin_simplenavi extends DokuWiki_Syntax_Plugin {
 
     function _cmp($a, $b) {
         global $conf;
-
-        $a = preg_replace('/:'.preg_quote($conf['start'], '/').'$/', '', $a);
-        $b = preg_replace('/:'.preg_quote($conf['start'], '/').'$/', '', $b);
+        $a = preg_replace('/'.preg_quote($conf['start'], '/').'$/', '', $a);
+        $b = preg_replace('/'.preg_quote($conf['start'], '/').'$/', '', $b);
+        $a = preg_replace('/:/', '/', $a);
+        $b = preg_replace('/:/', '/', $b);
 
         return strcmp($a, $b);
     }

--- a/syntax.php
+++ b/syntax.php
@@ -49,8 +49,10 @@ class syntax_plugin_simplenavi extends DokuWiki_Syntax_Plugin {
 
         $ns = utf8_encodeFN(str_replace(':','/',$pass[0]));
         $data = array();
-        search($data,$conf['datadir'],array($this,'_search'),array('ns' => $INFO['id']),$ns);
-        uksort($data, array($this, '_cmp'));
+        search($data,$conf['datadir'],array($this,'_search'),array('ns' => $INFO['id']),$ns,'natural');
+        if ($this->getConf('sort') == 'ascii') {
+            uksort($data, array($this, '_cmp'));
+        }
 
         $R->doc .= '<div class="plugin__simplenavi">';
         $R->doc .= html_buildlist($data,'idx',array($this,'_list'),array($this,'_li'));

--- a/syntax.php
+++ b/syntax.php
@@ -159,8 +159,8 @@ class syntax_plugin_simplenavi extends DokuWiki_Syntax_Plugin {
         global $conf;
         $a = preg_replace('/'.preg_quote($conf['start'], '/').'$/', '', $a);
         $b = preg_replace('/'.preg_quote($conf['start'], '/').'$/', '', $b);
-        $a = preg_replace('/:/', '/', $a);
-        $b = preg_replace('/:/', '/', $b);
+        $a = str_replace(':', '/', $a);
+        $b = str_replace(':', '/', $b);
 
         return strcmp($a, $b);
     }

--- a/syntax.php
+++ b/syntax.php
@@ -34,13 +34,13 @@ class syntax_plugin_simplenavi extends DokuWiki_Syntax_Plugin {
         $this->Lexer->addSpecialPattern('{{simplenavi>[^}]*}}',$mode,'plugin_simplenavi');
     }
 
-    function handle($match, $state, $pos, &$handler){
+    function handle($match, $state, $pos, Doku_Handler $handler){
         $data = array(cleanID(substr($match,13,-2)));
 
         return $data;
     }
 
-    function render($mode, &$R, $pass) {
+    function render($mode, Doku_Renderer $R, $pass) {
         if($mode != 'xhtml') return false;
 
         global $conf;

--- a/syntax.php
+++ b/syntax.php
@@ -49,7 +49,7 @@ class syntax_plugin_simplenavi extends DokuWiki_Syntax_Plugin {
 
         $ns = utf8_encodeFN(str_replace(':','/',$pass[0]));
         $data = array();
-        search($data,$conf['datadir'],array($this,'_search'),array('ns' => $INFO['id']),$ns,'natural');
+        search($data,$conf['datadir'],array($this,'_search'),array('ns' => $INFO['id']),$ns,1,'natural');
         if ($this->getConf('sort') == 'ascii') {
             uksort($data, array($this, '_cmp'));
         }


### PR DESCRIPTION
Adds an option to choose between natural sorting and sorting based on the ascii table, with natural sorting as the default.
Natural sorting just uses the natural sorting done by the `search` function.
Ascii sorting had a bug when multiple parallel namespaces only differed by similar numbers at the end, because the `:` char is behind numbers in the ascii table. This is fixed by replacing the `:` with a `/` char for sorting purposes.
Unittests and Travis integration for the above have also been added.

Further the signatures of the `render` and the `handle` function have been adjusted to the dokuwiki specifications.

A remaining possible issue: In the ascii sort pages are not sorted behind namespaces.