### PR TITLE
added optional option skipns for simplenavi call

### DIFF
--- a/syntax.php
+++ b/syntax.php
@@ -4,7 +4,7 @@
  *
  * @license GPL 2 http://www.gnu.org/licenses/gpl-2.0.html
  * @author  Andreas Gohr <gohr@cosmocode.de>
- * @author  Szymon Olewniczak <(my first name) [at] imz [dot] re>
+ * @author  Szymon Olewniczak <solewniczak@rid.pl>
  */
 
 // must be run within Dokuwiki
@@ -40,12 +40,12 @@ class syntax_plugin_simplenavi extends DokuWiki_Syntax_Plugin {
         
         //defaults
         $opts = array(
-			'skipns' => ''
+            'skipns' => ''
         );
         
         if(preg_match('/skipns=(\S+)/u', $optsstr, $sns) > 0) {
-			$opts['skipns'] = $sns[1];
-		}
+            $opts['skipns'] = $sns[1];
+        }
 
         $data = array(cleanID($nsstr), $opts);
 
@@ -151,8 +151,8 @@ class syntax_plugin_simplenavi extends DokuWiki_Syntax_Plugin {
         
         //check skipns
         if(!empty($opts['skipns']) && preg_match('/'.$opts['skipns'].'/ui',':'.$id)){
-			return false;
-		}
+                return false;
+        }
 
         $data[$id]=array( 'id'    => $id,
                        'type'  => $type,

--- a/syntax.php
+++ b/syntax.php
@@ -4,6 +4,7 @@
  *
  * @license GPL 2 http://www.gnu.org/licenses/gpl-2.0.html
  * @author  Andreas Gohr <gohr@cosmocode.de>
+ * @author  Szymon Olewniczak <(my first name) [at] imz [dot] re>
  */
 
 // must be run within Dokuwiki
@@ -35,7 +36,18 @@ class syntax_plugin_simplenavi extends DokuWiki_Syntax_Plugin {
     }
 
     function handle($match, $state, $pos, Doku_Handler $handler){
-        $data = array(cleanID(substr($match,13,-2)));
+        list($nsstr, $optsstr) = explode('|', substr($match,13,-2), 2);
+        
+        //defaults
+        $opts = array(
+			'skipns' => ''
+        );
+        
+        if(preg_match('/skipns=(\S+)/u', $optsstr, $sns) > 0) {
+			$opts['skipns'] = $sns[1];
+		}
+
+        $data = array(cleanID($nsstr), $opts);
 
         return $data;
     }
@@ -46,10 +58,13 @@ class syntax_plugin_simplenavi extends DokuWiki_Syntax_Plugin {
         global $conf;
         global $INFO;
         $R->info['cache'] = false;
+        
+        list($nsstr, $opts) = $pass;
 
-        $ns = utf8_encodeFN(str_replace(':','/',$pass[0]));
+        $ns = utf8_encodeFN(str_replace(':','/',$nsstr));
         $data = array();
-        search($data,$conf['datadir'],array($this,'_search'),array('ns' => $INFO['id']),$ns,1,'natural');
+        $opts['ns'] = $INFO['id'];
+        search($data,$conf['datadir'],array($this,'_search'),$opts,$ns,1,'natural');
         if ($this->getConf('sortByTitle') == true) {
             $this->_sortByTitle($data,"id");
         } else {
@@ -133,6 +148,11 @@ class syntax_plugin_simplenavi extends DokuWiki_Syntax_Plugin {
         if($type=='f' && auth_quickaclcheck($id) < AUTH_READ){
             return false;
         }
+        
+        //check skipns
+        if(!empty($opts['skipns']) && preg_match('/'.$opts['skipns'].'/ui',':'.$id)){
+			return false;
+		}
 
         $data[$id]=array( 'id'    => $id,
                        'type'  => $type,


### PR DESCRIPTION
Maybe it takes a bit of simplicity from this plugin but nevertheless it's very useful to me. I've added optional syntax for skipping namespaces in individual simplenavi instances. Syntax: 
`{{simplenavi>|skipns=pages to skip as in hidepages }}`

The main reason for this modification is using simplenavi together with [translation plugin](https://www.dokuwiki.org/plugin:translation) to hide translation namespaces:
`{{simplenavi>|skipns=en}}`