### PR TITLE
Obey ACL on namespaces

### DIFF
--- a/syntax.php
+++ b/syntax.php
@@ -130,7 +130,7 @@ class syntax_plugin_simplenavi extends DokuWiki_Syntax_Plugin {
         }
 
         //check ACL
-        if($type=='f' && auth_quickaclcheck($id) < AUTH_READ){
+        if(auth_quickaclcheck($id) < AUTH_READ){
             return false;
         }
 


### PR DESCRIPTION
It makes no sense to list a namespace container while all its pages are hidden because of ACL restrictions on that namespace. So please merge this PR proposed as fix for #6 . Thanks!